### PR TITLE
fix: swagger3.0 CORS 오류 수정

### DIFF
--- a/src/main/java/com/yogiga/yogiga/YogigaApplication.java
+++ b/src/main/java/com/yogiga/yogiga/YogigaApplication.java
@@ -1,11 +1,15 @@
 package com.yogiga.yogiga;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@OpenAPIDefinition(servers = {@Server(url = "/", description = "Default Server URL")})
+
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class YogigaApplication {
 


### PR DESCRIPTION
swagger3.0가 서버에서 실행시 http로 요청을 보내서 CORS 오류
main에 @OpenAPIDefinition 추가